### PR TITLE
Remove `DOCUMENTER_KEY` for regular documentation deployment

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -30,5 +30,4 @@ jobs:
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.JULIASIM_REGISTRY_SSH_KEY }} # For authentication with SSH deploy key
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
This secret is not actually necessary for deployment to work in this case. The `GITHUB_TOKEN` can also be used to push to the branch. Now that `DOCUMENTER_KEY` actually has a value and is set to an non-base64 encoded SSH key the deployment errors[^1].

Partially reverts 048a234.

[^1]: https://github.com/JuliaComputing/Multibody.jl/actions/runs/4697514324/jobs/8328667586