### PR TITLE
add wheel components

### DIFF
--- a/src/Multibody.jl
+++ b/src/Multibody.jl
@@ -37,7 +37,7 @@ include("interfaces.jl")
 export World, world, FixedTranslation, Body
 include("components.jl")
 
-export Revolute, Prismatic
+export Revolute, Prismatic, RollingWheelJoint, RollingWheel
 include("joints.jl")
 
 export Spring

--- a/src/components.jl
+++ b/src/components.jl
@@ -65,140 +65,6 @@ function FixedTranslation(; name, r0)
 end
 
 """
-    Revolute(; name, phi0 = 0, w0 = 0, n, useAxisFlange = false)
-
-Revolute joint with 1 rotational degree-of-freedom
-
-- `phi0`: Initial angle
-- `w0`: Iniitial angular velocity
-- `n`: The axis of rotation
-- `useAxisFlange`: If true, the joint will have two additional frames from Mechanical.Rotational, `axis` and `support`, between which rotational components such as springs and dampers can be connected.
-
-If `useAxisFlange`, flange connectors for ModelicaStandardLibrary.Mechanics.Rotational are also available:
-- `axis`: 1-dim. rotational flange that drives the joint
-- `support`: 1-dim. rotational flange of the drive support (assumed to be fixed in the world frame, NOT in the joint)
-"""
-function Revolute(; name, phi0 = 0, w0 = 0, n = Float64[0, 0, 1], useAxisFlange = false,
-                  isroot = false)
-    norm(n) ≈ 1 || error("Axis of rotation must be a unit vector")
-    @named frame_a = Frame()
-    @named frame_b = Frame()
-    @parameters n[1:3]=n [description = "axis of rotation"]
-    @variables tau(t)=0 [
-        connect = Flow,
-        description = "Driving torque in direction of axis of rotation",
-    ]
-    @variables phi(t)=phi0 [state_priority = 20, description = "Relative rotation angle from frame_a to frame_b"]
-    @variables w(t)=w0 [state_priority = 20, description = "angular velocity (rad/s)"]
-    Rrel0 = planar_rotation(n, phi0, w0)
-    @named Rrel = NumRotationMatrix(; R = Rrel0.R, w = Rrel0.w)
-    n = collect(n)
-
-    if isroot
-        eqs = Equation[Rrel ~ planar_rotation(n, phi, w)
-                       ori(frame_b) ~ abs_rotation(ori(frame_a), Rrel)
-                       collect(frame_a.f) .~ -resolve1(Rrel, frame_b.f)
-                       collect(frame_a.tau) .~ -resolve1(Rrel, frame_b.tau)]
-    else
-        eqs = Equation[Rrel ~ planar_rotation(-n, phi, w)
-                       ori(frame_a) ~ abs_rotation(ori(frame_b), Rrel)
-                       collect(frame_b.f) .~ -resolve1(Rrel, frame_a.f)
-                       collect(frame_b.tau) .~ -resolve1(Rrel, frame_a.tau)]
-    end
-    moreeqs = [collect(frame_a.r_0 .~ frame_b.r_0)
-               D(phi) ~ w
-               tau ~ -collect(frame_b.tau)'n]
-    append!(eqs, moreeqs)
-    if useAxisFlange
-        # @named internalAxis = Rotational.InternalSupport(tau=tau)
-        @named fixed = Rotational.Fixed()
-
-        @named axis = Rotational.Flange()
-        @named support = Rotational.Flange()
-        # push!(eqs, phi ~ internalAxis.phi)
-        push!(eqs, connect(fixed.flange, support))
-        push!(eqs, axis.phi ~ phi)
-        push!(eqs, axis.tau ~ tau)
-        # push!(eqs, connect(internalAxis.flange, axis))
-        compose(ODESystem(eqs, t; name), frame_a, frame_b, axis, support, fixed)
-    else
-        # Modelica Revolute uses a ConstantTorque as well as internalAxis = Rotational.InternalSupport(tau=tau), but it seemed more complicated than required and I couldn't get it to work, likely due to the `input` semantics of modelica not having an equivalent in MTK, so the (tau=tau) input argument caused problems.
-        # @named constantTorque = Rotational.ConstantTorque(tau_constant=0, use_support=false) 
-        # push!(eqs, connect(constantTorque.flange, internalAxis.flange))
-        push!(eqs, tau ~ 0)
-        compose(ODESystem(eqs, t; name), frame_a, frame_b)
-    end
-end
-
-"""
-    Prismatic(; name, n = [0, 0, 1], useAxisFlange = false, isroot = false)
-
-Prismatic joint with 1 translational degree-of-freedom
-
-- `n`: The axis of motion (unit vector)
-- `useAxisFlange`: If true, the joint will have two additional frames from Mechanical.Translational, `axis` and `support`, between which translational components such as springs and dampers can be connected.
-- `isroot`: If true, the joint will be considered the root of the system.
-
-If `useAxisFlange`, flange connectors for ModelicaStandardLibrary.Mechanics.TranslationalModelica are also available:
-- `axis`: 1-dim. translational flange that drives the joint
-- `support`: 1-dim. translational flange of the drive support (assumed to be fixed in the world frame, NOT in the joint)
-
-The function returns an ODESystem representing the prismatic joint.
-"""
-function Prismatic(; name, n = Float64[0, 0, 1], useAxisFlange = false,
-                   isroot = false)
-    norm(n) ≈ 1 || error("Axis of motion must be a unit vector")
-    @named frame_a = Frame()
-    @named frame_b = Frame()
-    @parameters n[1:3]=n [description = "axis of motion"]
-    n = collect(n)
-
-    @variables s(t)=0 [
-        state_priority = 10,
-        description = "Relative distance between frame_a and frame_b",
-    ]
-    @variables v(t)=0 [
-        state_priority = 10,
-        description = "Relative velocity between frame_a and frame_b",
-    ]
-    @variables a(t)=0 [
-        state_priority = 10,
-        description = "Relative acceleration between frame_a and frame_b",
-    ]
-    @variables f(t)=0 [
-        connect = Flow,
-        description = "Actuation force in direction of joint axis",
-    ]
-
-    eqs = [v ~ D(s)
-           a ~ D(v)
-
-           # relationships between kinematic quantities of frame_a and of frame_b
-           collect(frame_b.r_0) .~ collect(frame_a.r_0) + resolve1(ori(frame_a), n * s)
-           ori(frame_b) ~ ori(frame_a)
-
-           # Force and torque balance
-           zeros(3) .~ collect(frame_a.f + frame_b.f)
-           zeros(3) .~ collect(frame_a.tau + frame_b.tau + cross(n * s, frame_b.f))
-
-           # d'Alemberts principle
-           f .~ -n'collect(frame_b.f)]
-
-    if useAxisFlange
-        @named fixed = Translational.Fixed()
-        @named axis = Translational.Flange()
-        @named support = Translational.Flange()
-        push!(eqs, connect(fixed.flange, support))
-        push!(eqs, axis.s ~ s)
-        push!(eqs, axis.f ~ f)
-        compose(ODESystem(eqs, t; name), frame_a, frame_b, axis, support, fixed)
-    else
-        push!(eqs, f ~ 0)
-        compose(ODESystem(eqs, t; name), frame_a, frame_b)
-    end
-end
-
-"""
     Body(; name, m = 1, r_cm, I = collect(0.001 * LinearAlgebra.I(3)), isroot = false, phi0 = zeros(3), phid0 = zeros(3))
 
 Representing a body with 3 translational and 3 rotational degrees-of-freedom.
@@ -210,7 +76,13 @@ Representing a body with 3 translational and 3 rotational degrees-of-freedom.
 - `phi0`: Initial orientation, only applicable if `isroot = true`
 - `phid0`: Initial angular velocity
 """
-function Body(; name, m = 1, r_cm = [0, 0, 0], I = collect(0.001LinearAlgebra.I(3)),
+function Body(; name, m = 1, r_cm = [0, 0, 0],
+              I_11 = 0.001,
+              I_22 = 0.001,
+              I_33 = 0.001,
+              I_21 = 0,
+              I_31 = 0,
+              I_32 = 0,
               isroot = false, phi0 = zeros(3), phid0 = zeros(3))
     @variables r_0(t)[1:3]=0 [
         state_priority = 2,
@@ -237,12 +109,12 @@ function Body(; name, m = 1, r_cm = [0, 0, 0], I = collect(0.001LinearAlgebra.I(
     ]
     # @parameters I[1:3, 1:3]=I [description="inertia tensor"]
 
-    @parameters I_11=I[1, 1] [description = "Element (1,1) of inertia tensor"]
-    @parameters I_22=I[2, 2] [description = "Element (2,2) of inertia tensor"]
-    @parameters I_33=I[3, 3] [description = "Element (3,3) of inertia tensor"]
-    @parameters I_21=I[2, 1] [description = "Element (2,1) of inertia tensor"]
-    @parameters I_31=I[3, 1] [description = "Element (3,1) of inertia tensor"]
-    @parameters I_32=I[3, 2] [description = "Element (3,2) of inertia tensor"]
+    @parameters I_11=I_11 [description = "Element (1,1) of inertia tensor"]
+    @parameters I_22=I_22 [description = "Element (2,2) of inertia tensor"]
+    @parameters I_33=I_33 [description = "Element (3,3) of inertia tensor"]
+    @parameters I_21=I_21 [description = "Element (2,1) of inertia tensor"]
+    @parameters I_31=I_31 [description = "Element (3,1) of inertia tensor"]
+    @parameters I_32=I_32 [description = "Element (3,2) of inertia tensor"]
 
     I = [I_11 I_21 I_31; I_21 I_22 I_32; I_31 I_32 I_33]
 
@@ -291,102 +163,34 @@ function Body(; name, m = 1, r_cm = [0, 0, 0], I = collect(0.001LinearAlgebra.I(
     ODESystem(eqs, t; name, metadata = Dict(:isroot => isroot), systems = [frame_a])
 end
 
-function axesRotations(angles, der_angles, sequence = [1, 2, 3], name = :R_ar)
-    R = axisRotation(sequence[3], angles[3]) *
-        axisRotation(sequence[2], angles[2]) *
-        axisRotation(sequence[1], angles[1])
-
-    w = axis(sequence[3]) * der_angles[3] +
-        resolve2(axisRotation(sequence[3], angles[3]), axis(sequence[2]) * der_angles[2]) +
-        resolve2(axisRotation(sequence[3], angles[3]) *
-                 axisRotation(sequence[2], angles[2]),
-                 axis(sequence[1]) * der_angles[1])
-    RotationMatrix(R.R, w)
-end
-
-axis(s) = float.(s .== (1:3))
-
 """
-    axisRotation(sequence, angle; name = :R)
+    Inertia(; name, J, w0 = 0)
 
-Generate a rotation matrix for a rotation around the specified axis.
+A component representing the moment of inertia of a rotational body.
 
-- `sequence`: The axis to rotate around (1: x-axis, 2: y-axis, 3: z-axis)
-- `angle`: The angle of rotation (in radians)
+- `J`: Moment of inertia (kg.m^2)
+- `w0`: Initial angular velocity (rad/s)
 
-Returns a `RotationMatrix` object.
+The component has the following connectors:
+- `flange_a`: 1-dim. rotational flange of one side of the inertia
+- `flange_b`: 1-dim. rotational flange of the other side of the inertia
 """
-function axisRotation(sequence, angle; name = :R)
-    if sequence == 1
-        return RotationMatrix(rotx(angle), zeros(3))
-    elseif sequence == 2
-        return RotationMatrix(roty(angle), zeros(3))
-    elseif sequence == 3
-        return RotationMatrix(rotz(angle), zeros(3))
-    else
-        error("Invalid sequence $sequence")
-    end
-end
+function Inertia(; name, J, w0 = 0)
+    @parameters J=J [description = "Moment of inertia"]
+    @variables w(t)=w0 [state_priority = 20, description = "Angular velocity (rad/s)"]
+    @variables a(t) [description = "Angular acceleration (rad/s^2)"]
+    @variables phi(t) [
+        state_priority = 20,
+        description = "Rotation angle from flange_a to flange_b",
+    ]
+    @variables tau(t)=0 [connect = Flow, description = "Torque acting on flange_a"]
 
-"""
-    rotx(t, deg = false)
+    @named flange_a = Rotational.Flange(; phi = 0, tau = tau)
+    @named flange_b = Rotational.Flange(; phi = phi, tau = -tau)
 
-Generate a rotation matrix for a rotation around the x-axis.
+    eqs = [D(phi) ~ w,
+        D(w) ~ a,
+        J * a ~ tau]
 
-- `t`: The angle of rotation (in radians, unless `deg` is set to true)
-- `deg`: (Optional) If true, the angle is in degrees
-
-Returns a 3x3 rotation matrix.
-"""
-function rotx(t, deg = false)
-    if deg
-        t *= pi / 180
-    end
-    ct = cos(t)
-    st = sin(t)
-    R = [1 0 0
-         0 ct -st
-         0 st ct]
-end
-
-"""
-    roty(t, deg = false)
-
-Generate a rotation matrix for a rotation around the y-axis.
-
-- `t`: The angle of rotation (in radians, unless `deg` is set to true)
-- `deg`: (Optional) If true, the angle is in degrees
-
-Returns a 3x3 rotation matrix.
-"""
-function roty(t, deg = false)
-    if deg
-        t *= pi / 180
-    end
-    ct = cos(t)
-    st = sin(t)
-    R = [ct 0 st
-         0 1 0
-         -st 0 ct]
-end
-
-"""
-    rotz(t, deg = false)
-
-Generate a rotation matrix for a rotation around the z-axis.
-
-- `t`: The angle of rotation (in radians, unless `deg` is set to true)
-- `deg`: (Optional) If true, the angle is in degrees
-
-Returns a 3x3 rotation matrix.
-"""
-function rotz(t, deg = false)
-    if deg
-        t *= pi / 180
-    end
-    ct = cos(t)
-    st = sin(t)
-    R = [ct -st 0
-         st ct 0
-         0 0 1]
+    compose(ODESystem(eqs, t; name), flange_a, flange_b)
 end

--- a/src/joints.jl
+++ b/src/joints.jl
@@ -23,7 +23,10 @@ function Revolute(; name, phi0 = 0, w0 = 0, n = Float64[0, 0, 1], useAxisFlange 
         connect = Flow,
         description = "Driving torque in direction of axis of rotation",
     ]
-    @variables phi(t)=phi0 [state_priority = 20, description = "Relative rotation angle from frame_a to frame_b"]
+    @variables phi(t)=phi0 [
+        state_priority = 20,
+        description = "Relative rotation angle from frame_a to frame_b",
+    ]
     @variables w(t)=w0 [state_priority = 20, description = "angular velocity (rad/s)"]
     Rrel0 = planar_rotation(n, phi0, w0)
     @named Rrel = NumRotationMatrix(; R = Rrel0.R, w = Rrel0.w)
@@ -131,4 +134,236 @@ function Prismatic(; name, n = Float64[0, 0, 1], useAxisFlange = false,
         push!(eqs, f ~ 0)
         compose(ODESystem(eqs, t; name), frame_a, frame_b)
     end
+end
+
+"""
+    RollingWheelJoint(; name, radius, angles, x0, y0, z0)
+
+Joint (no mass, no inertia) that describes an ideal rolling wheel (rolling on the plane z=0). See [`RollingWheel`](@ref) for a realistic wheel model with inertia.
+
+A joint for a wheel rolling on the x-y plane of the world frame.
+The rolling contact is considered being ideal, i.e. there is no
+slip between the wheel and the ground. This is simply
+gained by two non-holonomic constraint equations on velocity level
+defined for both longitudinal and lateral direction of the wheel.
+There is also a holonomic constraint equation on position level
+granting a permanent contact of the wheel to the ground, i.e.
+the wheel can not take off.
+
+The origin of the frame `frame_a` is placed in the intersection
+of the wheel spin axis with the wheel middle plane and rotates
+with the wheel itself. The y-axis of `frame_a` is identical with
+the wheel spin axis, i.e. the wheel rotates about y-axis of `frame_a`.
+A wheel body collecting the mass and inertia should be connected to
+this frame.
+
+# Arguments and parameters:
+
+name: Name of the rolling wheel joint component
+radius: Radius of the wheel
+angles: Angles to rotate world-frame into frame_a around z-, y-, x-axis
+
+# Variables:
+- `x`: x-position of the wheel axis
+- `y`: y-position of the wheel axis
+- `z`: z-position of the wheel axis
+- `angles`: Angles to rotate world-frame into `frame_a` around z-, y-, x-axis
+- `der_angles`: Derivatives of angles
+- `r_road_0`: Position vector from world frame to contact point on road, resolved in world frame
+- `f_wheel_0`: Force vector on wheel, resolved in world frame
+- `f_n`: Contact force acting on wheel in normal direction
+- `f_lat`: Contact force acting on wheel in lateral direction
+- `f_long`: Contact force acting on wheel in longitudinal direction
+- `err`: Absolute value of `(r_road_0 - frame_a.r_0) - radius` (must be zero; used for checking)
+- `e_axis_0`: Unit vector along wheel axis, resolved in world frame
+- `delta_0`: Distance vector from wheel center to contact point
+- `e_n_0`: Unit vector in normal direction of road at contact point, resolved in world frame
+- `e_lat_0`: Unit vector in lateral direction of road at contact point, resolved in world frame
+- `e_long_0`: Unit vector in longitudinal direction of road at contact point, resolved in world frame
+- `s`: Road surface parameter 1
+- `w`: Road surface parameter 2
+- `e_s_0`: Road heading at `(s,w)`, resolved in world frame (unit vector)
+- `v_0`: Velocity of wheel center, resolved in world frame
+- `w_0`: Angular velocity of wheel, resolved in world frame
+- `vContact_0`: Velocity of contact point, resolved in world frame
+
+# Connector frames
+- `frame_a`: Frame for the wheel joint
+"""
+function RollingWheelJoint(; name, radius, angles = zeros(3), x0, y0, z0 = 0)
+    @named frame_a = Frame()
+    @parameters begin radius = radius, [description = "Radius of the wheel"] end
+    @variables begin
+        (x(t) = x0), [state_priority = 10, description = "x-position of the wheel axis"]
+        (y(t) = y0), [state_priority = 10, description = "y-position of the wheel axis"]
+        (z(t) = z0), [state_priority = 10, description = "z-position of the wheel axis"]
+        (angles(t)[1:3] = angles),
+        [description = "Angles to rotate world-frame into frame_a around z-, y-, x-axis"]
+        (der_angles(t)[1:3] = zeros(3)), [description = "Derivatives of angles"]
+        (r_road_0(t)[1:3] = zeros(3)),
+        [
+            description = "Position vector from world frame to contact point on road, resolved in world frame",
+        ]
+        (f_wheel_0(t)[1:3] = zeros(3)),
+        [description = "Force vector on wheel, resolved in world frame"]
+        (f_n(t) = 0), [description = "Contact force acting on wheel in normal direction"]
+        (f_lat(t) = 0), [
+            description = "Contact force acting on wheel in lateral direction",
+        ]
+        (f_long(t) = 0),
+        [description = "Contact force acting on wheel in longitudinal direction"]
+        (err(t) = 0),
+        [
+            description = "|r_road_0 - frame_a.r_0| - radius (must be zero; used for checking)",
+        ]
+        (e_axis_0(t)[1:3] = zeros(3)),
+        [description = "Unit vector along wheel axis, resolved in world frame"]
+        (delta_0(t)[1:3] = zeros(3)),
+        [description = "Distance vector from wheel center to contact point"]
+        (e_n_0(t)[1:3] = zeros(3)),
+        [
+            description = "Unit vector in normal direction of road at contact point, resolved in world frame",
+        ]
+        (e_lat_0(t)[1:3] = zeros(3)),
+        [
+            description = "Unit vector in lateral direction of road at contact point, resolved in world frame",
+        ]
+        (e_long_0(t)[1:3] = zeros(3)),
+        [
+            description = "Unit vector in longitudinal direction of road at contact point, resolved in world frame",
+        ]
+
+        (s(t) = 0), [state_priority = 10, description = "Road surface parameter 1"]
+        (w(t) = 0), [state_priority = 10, description = "Road surface parameter 2"]
+        (e_s_0(t)[1:3] = zeros(3)),
+        [description = "Road heading at (s,w), resolved in world frame (unit vector)"]
+
+        (v_0(t)[1:3] = zeros(3)),
+        [description = "Velocity of wheel center, resolved in world frame"]
+        (w_0(t)[1:3] = zeros(3)),
+        [description = "Angular velocity of wheel, resolved in world frame"]
+        (vContact_0(t)[1:3] = zeros(3)),
+        [description = "Velocity of contact point, resolved in world frame"]
+
+        (aux(t)[1:3] = zeros(3)), [description = "Auxiliary variable"]
+    end
+
+    equations = [
+                 # frame_a.R is computed from generalized coordinates
+                 collect(frame_a.r_0) .~ [x, y, z]
+                 collect(der_angles) .~ D.(angles)
+                 ori(frame_a) ~ axesRotations(angles, der_angles, [3, 2, 1])
+
+                 # Road description
+                 collect(r_road_0) .~ [s, w, 0]
+                 collect(e_n_0) .~ [0, 0, 1]
+                 collect(e_s_0) .~ [1, 0, 0]
+
+                 # Coordinate system at contact point (e_long_0, e_lat_0, e_n_0)
+                 collect(e_axis_0) .~ resolve1(ori(frame_a), [0, 1, 0])
+                 collect(aux) .~ collect(cross(e_n_0, e_axis_0))
+                 collect(e_long_0) .~ collect(aux ./ norm(aux))
+                 collect(e_lat_0) .~ collect(cross(e_long_0, e_n_0))
+
+                 # Determine point on road where the wheel is in contact with the road
+                 collect(delta_0) .~ collect(r_road_0 - frame_a.r_0)
+                 0 ~ delta_0'e_axis_0
+                 0 ~ delta_0'e_long_0
+
+                 # One holonomic positional constraint equation (no penetration in to the ground)
+                 0 ~ radius - delta_0'cross(e_long_0, e_axis_0)
+
+                 # only for testing
+                 err ~ norm(delta_0) - radius
+
+                 # Slip velocities
+                 collect(v_0) .~ D.(frame_a.r_0)
+                 collect(w_0) .~ angular_velocity1(ori(frame_a))
+                 collect(vContact_0) .~ collect(v_0) + cross(w_0, delta_0)
+
+                 # Two non-holonomic constraint equations on velocity level (ideal rolling, no slippage)
+                 0 ~ vContact_0'e_long_0
+                 0 ~ vContact_0'e_lat_0
+
+                 # Contact force
+                 f_wheel_0 ~ f_n * e_n_0 + f_lat * e_lat_0 + f_long * e_long_0
+
+                 # Force and torque balance at the wheel center
+                 zeros(3) .~ collect(frame_a.f) + resolve2(ori(frame_a), f_wheel_0)
+                 zeros(3) .~ collect(frame_a.tau) +
+                             resolve2(ori(frame_a), cross(delta_0, f_wheel_0))]
+    compose(ODESystem(equations, t; name), frame_a)
+end
+
+"""
+    RollingWheel(; name, radius, m, I_axis, I_long, width=0.035, x0, y0, kwargs...)
+
+Ideal rolling wheel on flat surface z=0 (5 positional, 3 velocity degrees of freedom)
+
+A wheel rolling on the x-y plane of the world frame including wheel mass.
+The rolling contact is considered being ideal, i.e. there is no
+slip between the wheel and the ground.
+The wheel can not take off but it can incline toward the ground.
+The frame frame_a is placed in the wheel center point and rotates
+with the wheel itself.
+
+# Arguments and parameters:
+- `name`: Name of the rolling wheel component
+- `radius`: Radius of the wheel
+- `m`: Mass of the wheel
+- `I_axis`: Moment of inertia of the wheel along its axis
+- `I_long`: Moment of inertia of the wheel perpendicular to its axis
+- `width`: Width of the wheel (default: 0.035)
+- `x0`: Initial x-position of the wheel axis
+- `y0`: Initial y-position of the wheel axis
+- `kwargs...`: Additional keyword arguments passed to the `RollingWheelJoint` function
+
+# Variables:
+- `x`: x-position of the wheel axis
+- `y`: y-position of the wheel axis
+- `angles`: Angles to rotate world-frame into `frame_a` around z-, y-, x-axis
+- `der_angles`: Derivatives of angles
+
+# Named components:
+- `frame_a`: Frame for the wheel component
+- `rollingWheel`: Rolling wheel joint representing the wheel's contact with the road surface
+"""
+function RollingWheel(; name, radius, m, I_axis, I_long, width = 0.035, x0, y0,
+                      angles = zeros(3), der_angles = zeros(3), kwargs...)
+    @named begin
+        frame_a = Frame()
+        rollingWheel = RollingWheelJoint(; radius, angles, x0, y0, kwargs...)
+        body = Body(r_cm = [0, 0, 0],
+                    m = m,
+                    I_11 = I_long,
+                    I_22 = I_axis,
+                    I_33 = I_long,
+                    I_21 = 0,
+                    I_31 = 0,
+                    I_32 = 0)
+    end
+    pars = @parameters begin
+        radius = radius, [description = "Radius of the wheel"]
+        m = m, [description = "Mass of the wheel"]
+        I_axis = I_axis, [description = "Moment of inertia of the wheel along its axis"]
+        I_long = I_long,
+                 [description = "Moment of inertia of the wheel perpendicular to its axis"]
+        width = width, [description = "Width of the wheel"]
+    end
+    sts = @variables begin
+        (x(t) = x0), [state_priority = 10, description = "x-position of the wheel axis"]
+        (y(t) = y0), [state_priority = 10, description = "y-position of the wheel axis"]
+        (angles(t)[1:3] = angles),
+        [description = "Angles to rotate world-frame into frame_a around z-, y-, x-axis"]
+        (der_angles(t)[1:3] = der_angles), [description = "Derivatives of angles"]
+    end
+    sts = reduce(vcat, collect.(sts))
+
+    equations = Equation[rollingWheel.x ~ x
+                         rollingWheel.y ~ y
+                         collect(rollingWheel.angles) .~ collect(angles)
+                         collect(rollingWheel.der_angles) .~ collect(der_angles)
+                         connect(body.frame_a, frame_a)
+                         connect(rollingWheel.frame_a, frame_a)]
+    compose(ODESystem(equations, t, sts, pars; name), frame_a, rollingWheel, body)
 end

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -128,6 +128,10 @@ function angular_velocity2(R::RotationMatrix)
     R.w
 end
 
+function angular_velocity1(R::RotationMatrix)
+    resolve1(R, R.w)
+end
+
 function orientation_constraint(R::RotationMatrix)
     T = R.R
     [T[:, 1]'T[:, 1] - 1
@@ -156,8 +160,6 @@ function angular_velocity2(q::AbstractVector, q̇)
     Q = [q[4] q[3] -q[2] -q[1]; -q[3] q[4] q[1] -q[2]; q[2] -q[1] q[4] -q[3]]
     2 * Q * q̇
 end
-
-
 
 function axesRotations(angles, der_angles, sequence = [1, 2, 3], name = :R_ar)
     R = axisRotation(sequence[3], angles[3]) *


### PR DESCRIPTION
Currently fails upon [creating the `ODEProblem`](https://github.com/JuliaComputing/Multibody.jl/pull/14/files#diff-3b9314a6f9f2d7eec1d0ef69fa76cfabafdbe6d0df923768f9ec32f27a249c63R291) with 
```julia
ERROR: AssertionError: ex isa Number
Stacktrace:
  [1] extract_ir(ex::Vector{Num}, iv::Nothing)
    @ SymbolicIR.SymbolicsConversion ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/SymbolicsConversion.jl:56
  [2] extract_ir(ex::Vector{Num})
    @ SymbolicIR.SymbolicsConversion ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/SymbolicsConversion.jl:20
  [3] (::SymbolicIR.var"#110#112")(::Pair{AbstractVector{Num}, Vector{Int64}})
    @ SymbolicIR ./none:0
  [4] iterate
    @ ./generator.jl:47 [inlined]
  [5] Dict{IRElement, Any}(kv::Base.Generator{Vector{Pair{AbstractVector{Num}, Vector{Int64}}}, SymbolicIR.var"#110#112"})
    @ Base ./dict.jl:85
  [6] (ODEProblem{true})(ss::SymbolicIR.ScheduledSystem, u0::Vector{Pair{AbstractVector{Num}, Vector{Int64}}}, tspan::Tuple{Int64, Int64}, p::Type; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ SymbolicIR ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/dae_transformations.jl:819
  [7] ODEProblem
    @ ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/dae_transformations.jl:808 [inlined]
  [8] (ODEProblem{true})(ss::SymbolicIR.ScheduledSystem, u0::Vector{Pair{AbstractVector{Num}, Vector{Int64}}}, tspan::Tuple{Int64, Int64})
    @ SymbolicIR ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/dae_transformations.jl:808
  [9] ODEProblem(::SymbolicIR.ScheduledSystem, ::Vector{Pair{AbstractVector{Num}, Vector{Int64}}}, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ SymbolicIR ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/dae_transformations.jl:806
 [10] ODEProblem(::SymbolicIR.ScheduledSystem, ::Vector{Pair{AbstractVector{Num}, Vector{Int64}}}, ::Vararg{Any})
    @ SymbolicIR ~/.julia/packages/SymbolicIR/cV6CW/src/structural_transformation/dae_transformations.jl:805
 [11] top-level scope
    @ ~/.julia/dev/Multibody/test/runtests.jl:289
```
cc @YingboMa 