### PR TITLE
make world render parameters configurable

### DIFF
--- a/ext/Render.jl
+++ b/ext/Render.jl
@@ -283,26 +283,27 @@ end
 
 function render!(scene, ::typeof(World), sys, sol, t)
     sol(sol.t[1], idxs=sys.render)==true || return true # yes, == true
-    radius = 0.01f0
+    radius = sol(sol.t[1], idxs=sys.radius) |> Float32
+    length = sol(sol.t[1], idxs=sys.length) |> Float32
     r_0 = get_fun(sol, collect(sys.frame_b.r_0))
 
     thing = @lift begin
         O = Point3f(r_0($t)) # Assume world is never moving
-        x = O .+ Point3f(1,0,0)
+        x = O .+ Point3f(length,0,0)
         Makie.GeometryBasics.Cylinder(O, x, radius)
     end
     mesh!(scene, thing, color=:red)
 
     thing = @lift begin
         O = Point3f(r_0($t))
-        y = O .+ Point3f(0,1,0)
+        y = O .+ Point3f(0,length,0)
         Makie.GeometryBasics.Cylinder(O, y, radius)
     end
     mesh!(scene, thing, color=:green)
 
     thing = @lift begin
         O = Point3f(r_0($t))
-        z = O .+ Point3f(0,0,1)
+        z = O .+ Point3f(0,0,length)
         Makie.GeometryBasics.Cylinder(O, z, radius)
     end
     mesh!(scene, thing, color=:blue)

--- a/src/components.jl
+++ b/src/components.jl
@@ -49,12 +49,15 @@ end
     @parameters mu=3.986004418e14 [description = "Gravity field constant [m³/s²] (default = field constant of earth)"]
     @parameters render=render
     @parameters point_gravity = point_gravity
+    @parameters radius = 0.01f0
+    @parameters length = 1
+    
     O = ori(frame_b)
     eqs = Equation[collect(frame_b.r_0) .~ 0;
                    O ~ nullrotation()
                    # vec(D(O).R .~ 0); # QUESTION: not sure if I should have to add this, should only have 12 equations according to modelica paper
                    ]
-    ODESystem(eqs, t, [], [n; g; mu; point_gravity; render]; name, systems = [frame_b])
+    ODESystem(eqs, t, [], [n; g; mu; point_gravity; render; radius; length]; name, systems = [frame_b])
 end
 
 """
@@ -578,6 +581,26 @@ end
 # end
 
 
+"""
+    BodyCylinder(; name, m = 1, r = [0.1, 0, 0], r_shape = [0, 0, 0], dir = r - r_shape, length = _norm(r - r_shape), diameter = 1, inner_diameter = 0, density = 7700, color = purple)
+
+Rigid body with cylinder shape. The mass properties of the body (mass, center of mass, inertia tensor) are computed from the cylinder data. Optionally, the cylinder may be hollow. The two connector frames `frame_a` and `frame_b` are always parallel to each other.
+
+# Parameters
+- `r`: (Structural parameter) Vector from `frame_a` to `frame_b` resolved in `frame_a`
+- `r_shape`: (Structural parameter) Vector from `frame_a` to cylinder origin, resolved in `frame_a`
+- `dir`: Vector in length direction of cylinder, resolved in `frame_a`
+- `length`: Length of cylinder
+- `diameter`: Diameter of cylinder
+- `inner_diameter`: Inner diameter of cylinder (0 <= inner_diameter <= diameter)
+- `density`: Density of cylinder [kg/m³] (e.g., steel: 7700 .. 7900, wood : 400 .. 800)
+- `color`: Color of cylinder in animations
+
+# Variables
+- `r_0`: Position vector from origin of world frame to origin of `frame_a`
+- `v_0`: Absolute velocity of `frame_a`, resolved in world frame (= D(r_0))
+- `a_0`: Absolute acceleration of `frame_a` resolved in world frame (= D(v_0))
+"""
 @mtkmodel BodyCylinder begin
 
     @structural_parameters begin
@@ -610,7 +633,7 @@ end
             description = "Inner diameter of cylinder (0 <= inner_diameter <= diameter)",
         ]
         density = 7700, [
-            description = "Density of cylinder (e.g., steel: 7700 .. 7900, wood : 400 .. 800)",
+            description = "Density of cylinder [kg/m³] (e.g., steel: 7700 .. 7900, wood : 400 .. 800)",
         ]
         color[1:4] = purple, [description = "Color of cylinder in animations"]
     end
@@ -680,7 +703,7 @@ Rigid body with box shape. The mass properties of the body (mass, center of mass
 - `height = width`: Height of box
 - `inner_width`: Width of inner box surface (0 <= inner_width <= width)
 - `inner_height`: Height of inner box surface (0 <= inner_height <= height)
-- `density = 7700`: Density of cylinder (e.g., steel: 7700 .. 7900, wood : 400 .. 800)
+- `density = 7700`: Density of box [kg/m³] (e.g., steel: 7700 .. 7900, wood : 400 .. 800)
 - `color`: Color of box in animations
 """
 @mtkmodel BodyBox begin
@@ -737,7 +760,7 @@ Rigid body with box shape. The mass properties of the body (mass, center of mass
             description = "Height of inner box surface (0 <= inner_height <= height)",
         ]
         density = 7700, [
-            description = "Density of cylinder (e.g., steel: 7700 .. 7900, wood : 400 .. 800)",
+            description = "Density of cylinder [kg/m³] (e.g., steel: 7700 .. 7900, wood : 400 .. 800)",
         ]
         color[1:4] = purple, [description = "Color of box in animations"]
     end


### PR DESCRIPTION
This changes the pendulum to use the `BodyCylinder` component instead of `BodyShape`. `BodyCylinder.r` unfortunately has to be a structural parameter due to JSCompiler bug. This in turn breaks the rest of the tutorial which uses this parameter.

Issue: https://github.com/JuliaComputing/JuliaSimCompiler.jl/issues/334