### PR TITLE
add compile-time optimization based on parameter values

### DIFF
--- a/test/test_robot.jl
+++ b/test/test_robot.jl
@@ -316,3 +316,36 @@ end
     @test maximum(abs, control_error) < 0.01
 end
 
+
+
+@testset "subs constants" begin
+    @info "Testing subs constants"
+    @named robot = Robot6DOF()
+    robot = complete(robot)
+    ssys = structural_simplify(IRSystem(robot))
+    ssys = Multibody.subs_constants(robot; ssys)
+    prob = ODEProblem(ssys, [
+        robot.mechanics.r1.phi => deg2rad(-60)
+        robot.mechanics.r2.phi => deg2rad(20)
+        robot.mechanics.r3.phi => deg2rad(90)
+        robot.mechanics.r4.phi => deg2rad(0)
+        robot.mechanics.r5.phi => deg2rad(-110)
+        robot.mechanics.r6.phi => deg2rad(0)
+
+        robot.axis1.motor.Jmotor.phi => deg2rad(-60) * (-105) # Multiply by gear ratio
+        robot.axis2.motor.Jmotor.phi => deg2rad(20) * (210)
+        robot.axis3.motor.Jmotor.phi => deg2rad(90) * (60)
+    ], (0.0, 2.0))
+    sol2 = solve(prob, Rodas5P(autodiff=false))
+
+    @test SciMLBase.successful_retcode(sol2)
+
+    tv = 0:0.1:2
+    # control_error = sol2(tv, idxs=robot.pathPlanning.controlBus.axisControlBus1.angle_ref-robot.pathPlanning.controlBus.axisControlBus1.angle)
+    # @test maximum(abs, control_error) < 0.002
+
+    # using BenchmarkTools
+    # @btime solve(prob, Rodas5P(autodiff=false));
+    # 152.225 ms (2272926 allocations: 40.08 MiB)
+    # 114.113 ms (1833534 allocations: 33.38 MiB) # sub 0, 1
+end


### PR DESCRIPTION
Status: Waiting for JSCompiler release

In multibody models, many parameters are sparse, e.g., arrays like `[1, 0, 0]` or diagonal inertia matrices. Allowing JSCompiler to make use of this information when simplifying the system and generating code can lead to a 2x performance boost for multibody simulations. The downside is of course that those parameters cannot be changed without recompiling. It's thus only worthwhile for simulations where runtime is longer than compile time. 

To see why this makes such a big difference, consider the expression `R'*I*R` where the matrices are both 3x3. Without any structure, this expands to the computation
```julia
julia> collect(R'I*R)
3×3 Matrix{Num}:
 (I[1, 1]*R[1, 1] + I[2, 1]*R[2, 1] + I[3, 1]*R[3, 1])*R[1, 1] + (I[1, 2]*R[1, 1] + I[2, 2]*R[2, 1] + I[3, 2]*R[3, 1])*R[2, 1] + (I[1, 3]*R[1, 1] + I[2, 3]*R[2, 1] + I[3, 3]*R[3, 1])*R[3, 1]  …  (I[1, 1]*R[1, 1] + I[2, 1]*R[2, 1] + I[3, 1]*R[3, 1])*R[1, 3] + (I[1, 2]*R[1, 1] + I[2, 2]*R[2, 1] + I[3, 2]*R[3, 1])*R[2, 3] + (I[1, 3]*R[1, 1] + I[2, 3]*R[2, 1] + I[3, 3]*R[3, 1])*R[3, 3]
 (I[1, 1]*R[1, 2] + I[2, 1]*R[2, 2] + I[3, 1]*R[3, 2])*R[1, 1] + (I[1, 2]*R[1, 2] + I[2, 2]*R[2, 2] + I[3, 2]*R[3, 2])*R[2, 1] + (I[1, 3]*R[1, 2] + I[2, 3]*R[2, 2] + I[3, 3]*R[3, 2])*R[3, 1]     (I[1, 1]*R[1, 2] + I[2, 1]*R[2, 2] + I[3, 1]*R[3, 2])*R[1, 3] + (I[1, 2]*R[1, 2] + I[2, 2]*R[2, 2] + I[3, 2]*R[3, 2])*R[2, 3] + (I[1, 3]*R[1, 2] + I[2, 3]*R[2, 2] + I[3, 3]*R[3, 2])*R[3, 3]
 (I[1, 1]*R[1, 3] + I[2, 1]*R[2, 3] + I[3, 1]*R[3, 3])*R[1, 1] + (I[1, 2]*R[1, 3] + I[2, 2]*R[2, 3] + I[3, 2]*R[3, 3])*R[2, 1] + (I[1, 3]*R[1, 3] + I[2, 3]*R[2, 3] + I[3, 3]*R[3, 3])*R[3, 1]     (I[1, 1]*R[1, 3] + I[2, 1]*R[2, 3] + I[3, 1]*R[3, 3])*R[1, 3] + (I[1, 2]*R[1, 3] + I[2, 2]*R[2, 3] + I[3, 2]*R[3, 3])*R[2, 3] + (I[1, 3]*R[1, 3] + I[2, 3]*R[2, 3] + I[3, 3]*R[3, 3])*R[3, 3]
```

If we know that `R` is diagonal (very common case), we get
```julia
julia> collect(Rr'I*Rr)
3×3 Matrix{Num}:
  I[1, 1]*(r[1]^2)  I[1, 2]*r[1]*r[2]  I[1, 3]*r[1]*r[3]
 I[2, 1]*r[1]*r[2]   I[2, 2]*(r[2]^2)  I[2, 3]*r[2]*r[3]
 I[3, 1]*r[1]*r[3]  I[3, 2]*r[2]*r[3]   I[3, 3]*(r[3]^2)
```
If we know that `I` is diagonal we get
```julia
julia> R'Ii*R
3×3 Matrix{Num}:
             (R[1, 1]^2)*i[1] + (R[2, 1]^2)*i[2] + (R[3, 1]^2)*i[3]  R[1, 1]*R[1, 2]*i[1] + R[2, 1]*R[2, 2]*i[2] + R[3, 1]*R[3, 2]*i[3]  R[1, 1]*R[1, 3]*i[1] + R[2, 1]*R[2, 3]*i[2] + R[3, 1]*R[3, 3]*i[3]
 R[1, 1]*R[1, 2]*i[1] + R[2, 1]*R[2, 2]*i[2] + R[3, 1]*R[3, 2]*i[3]              (R[1, 2]^2)*i[1] + (R[2, 2]^2)*i[2] + (R[3, 2]^2)*i[3]  R[1, 2]*R[1, 3]*i[1] + R[2, 2]*R[2, 3]*i[2] + R[3, 2]*R[3, 3]*i[3]
 R[1, 1]*R[1, 3]*i[1] + R[2, 1]*R[2, 3]*i[2] + R[3, 1]*R[3, 3]*i[3]  R[1, 2]*R[1, 3]*i[1] + R[2, 2]*R[2, 3]*i[2] + R[3, 2]*R[3, 3]*i[3]              (R[1, 3]^2)*i[1] + (R[2, 3]^2)*i[2] + (R[3, 3]^2)*i[3]
```
and if both are diagonal, we get
```julia
julia> Rr'Ii*Rr
3×3 Diagonal{Num, Vector{Num}}:
 i[1]*(r[1]^2)              ⋅              ⋅
             ⋅  i[2]*(r[2]^2)              ⋅
             ⋅              ⋅  i[3]*(r[3]^2)
```

The PR #123 adds an explicit option to handle structural zeros in inertia matrices only, but this PR adds more of a nuclear option using `JuliaSimCompiler.freeze_parameters`, replacing all parameters that have the value 0 or 1 with their value. For a simple model of a car, this improved both simulation and RHS time by 2x.


Code for the above
```julia
@parameters R[1:3, 1:3] I[1:3, 1:3];
R,I = collect.((R,I));
collect(R'I*R)

# # With known zeros
@parameters r[1:3];
r = collect(r);
Rr = Diagonal(collect(r));
collect(Rr'I*Rr)

@parameters i[1:3];
i = collect(i);
Ii = Diagonal(collect(i));
R'Ii*R
```