### PR TITLE
introduce some intermediate level parameters

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -540,6 +540,7 @@ See also [`BodyCylinder`](@ref) and [`BodyBox`](@ref) for body components with p
         frame_cm = Frame()
     end
 
+    # NOTE: these parameters should be defined before the `systems` block above, but due to bugs in MTK/JSC with higher-order array parameters we cannot do that. We still define the parameters so that they are available to make animations
     @variables r_0(t)[1:3]=r_0 [
         state_priority = 2,
         description = "Position vector from origin of world frame to origin of frame_a",

--- a/src/robot/FullRobot.jl
+++ b/src/robot/FullRobot.jl
@@ -247,7 +247,6 @@ function Robot6DOF(; name, kwargs...)
 
         controlBus = ControlBus()
     end
-    push!(systems, world)
 
     eqs = [connect(axis2.flange, mechanics.axis2)
            connect(axis1.flange, mechanics.axis1)

--- a/src/robot/FullRobot.jl
+++ b/src/robot/FullRobot.jl
@@ -247,6 +247,7 @@ function Robot6DOF(; name, kwargs...)
 
         controlBus = ControlBus()
     end
+    push!(systems, world)
 
     eqs = [connect(axis2.flange, mechanics.axis2)
            connect(axis1.flange, mechanics.axis1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,8 @@ using Test
 using JuliaSimCompiler
 using OrdinaryDiffEq
 using LinearAlgebra
-t = Multibody.t
-D = Differential(t)
+isdefined(Main, :t) || (t = Multibody.t)
+isdefined(Main, :D) || (D = Differential(t))
 doplot() = false
 world = Multibody.world
 
@@ -1124,6 +1124,7 @@ using LinearAlgebra
 
     prob = ODEProblem(ssys, [model.joint.phi => 0], (0, 1))
     sol = solve(prob, Rodas5P(), abstol=1e-8, reltol=1e-8)
+    @test SciMLBase.successful_retcode(sol)
     # first(render(model, sol, 0, x=2.5, y=1.5, z=2.5, show_axis=true))
     # @test sol(10, idxs=model.body.body.m) ≈ 226.27 rtol=1e-3 # Values from open modelica
     # @test sol(10, idxs=model.body.body.I_11) ≈ 245.28 rtol=1e-3
@@ -1148,8 +1149,6 @@ end
 
 using LinearAlgebra, ModelingToolkit, Multibody, JuliaSimCompiler, OrdinaryDiffEq
 using Multibody.Rotations: RotXYZ
-t = Multibody.t
-D = Multibody.D
 world = Multibody.world
 
 @named joint = Multibody.Spherical(isroot=false, state=false, quat=false)

--- a/test/test_quaternions.jl
+++ b/test/test_quaternions.jl
@@ -198,7 +198,6 @@ end
 
 # @testset "Spherical joint with quaternion state" begin
     using LinearAlgebra, ModelingToolkit, Multibody, JuliaSimCompiler
-    t = Multibody.t
     world = Multibody.world
 
 
@@ -220,7 +219,7 @@ end
     ssys = structural_simplify(irsys)
 
 
-    D = Differential(t)
+    isdefined(Main, :D) || (D = Differential(t))
     # q0 = randn(4); q0 ./= norm(q0)
     # q0 = [1,0,0,0]
     prob = ODEProblem(ssys, [


### PR DESCRIPTION
This PR depends on:
- https://github.com/SciML/ModelingToolkit.jl/pull/3072
    - new release

Note to self: If one of the errors 
```
 The initial condition for parameter body₊body₊m isn't provided.
```
```
car₊body₊m cannot be converted to Float64. Please provide a default value for the symbolic variables.
```
appear, it might be due to parameters being forwarded straight through a component like `BodyShape` using the `kwargs...`, and the default for the parameter in the inner body does not find the corresponding parameter in the ParentScope (BodyShape). By introducing the same parameter in the BodyShape, this is resolved. 

It can also happen if `pars` aren't provided to the `ODESystem` constructor in the component that defines them.